### PR TITLE
Update build files to install standard library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,6 @@ build:
 install: all
 	dune b @install --profile=release
 	dune    install --profile=release
-	$(MKDIR) -p `opam var share`/Lama/x64
-	$(INSTALL) $(shell ls _build/default/stdlib/x64/*.[oi] _build/default/stdlib/x64/stdlib/*.lama \
-		runtime/runtime.a runtime/Std.i) \
-		`opam var share`/Lama/x64
-	$(MKDIR) -p `opam var share`/Lama/x32
-	$(INSTALL) $(shell ls _build/default/stdlib/x32/*.[oi] _build/default/stdlib/x32/stdlib/*.lama \
-		runtime32/runtime.a runtime32/Std.i) \
-		`opam var share`/Lama/x32
 
 _build/default/Lama.install: 
 	dune b @install

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,6 @@
-(lang dune 3.3)
+(lang dune 3.11)
+
+(name Lama)
 
 (cram enable)
 

--- a/runtime/dune
+++ b/runtime/dune
@@ -5,3 +5,9 @@
  (deps Makefile gc.c gc.h runtime_common.h runtime.c runtime.h printf.S)
  (action
   (run make)))
+
+(install
+ (section share)
+ (files
+  (runtime.a as x64/runtime.a)
+  (Std.i as x64/Std.i)))

--- a/runtime32/dune
+++ b/runtime32/dune
@@ -7,3 +7,9 @@
  (deps Makefile gc_runtime.s runtime.c runtime.h)
  (action
   (run make -j2)))
+
+(install
+ (section share)
+ (files
+  (runtime.a as x32/runtime.a)
+  (Std.i as x32/Std.i)))

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -1,0 +1,5 @@
+(install
+ (section share)
+ (files
+  (glob_files (*.lama with_prefix x64))
+  (glob_files (*.lama with_prefix x32))))

--- a/stdlib/x32/dune
+++ b/stdlib/x32/dune
@@ -60,3 +60,8 @@
       LAMAC
       "../../src/Driver.exe -32 -I ../../runtime32"
       (run make -j2 -f ../Makefile all)))))))
+(install
+ (section share)
+ (files
+  (glob_files (*.i with_prefix x32))
+  (glob_files (*.o with_prefix x32))))

--- a/stdlib/x64/dune
+++ b/stdlib/x64/dune
@@ -57,3 +57,9 @@
       LAMAC
       "../../src/Driver.exe -64 -I ../../runtime"
       (run make -j2 -f ../Makefile all)))))))
+
+(install
+ (section share)
+ (files
+  (glob_files (*.i with_prefix x64))
+  (glob_files (*.o with_prefix x64))))


### PR DESCRIPTION
Обновил сборку через dune. До этого фикса при установке пакета через opam файлы стандартной библиотеки и рантайма не копировались в нужные директории.

Искомые директории подсмотрел в Makefile. Правда, обратил внимание, что исходные коды стандартной библиотеки копировались неправильно.

Для удобных директив в dune файлах обновил версию синтаксиса в dune-project. Надеюсь, что это не breaking change, по крайней мере, когда я тестировал, у меня ничего не сломалось.